### PR TITLE
Use rather case insensitive pgrep

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function main(args, pid) {
     process.exit(1) }
 
   var processName = last(args).get()
-  var processes   = shell('pgrep', [processName])
+  var processes   = shell('pgrep -i', [processName])
   var toKill      = processes.map(function(data) {
                                     return parseIds(data.output).filter(notEqual(pid))
                                                                 .map(kill) })


### PR DESCRIPTION
Hi,

wouldn't be better to use case insensitive process matching?

So we can type fuck you chrome instead of fuck you Chrome :)