### PR TITLE
fixed process name matching in osx

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,7 +119,7 @@ function match(pid, pattern){ return function(process) {
 
 // :: String -> RegExp
 function toRegExp(pattern) {
-  return new RegExp('^' + escape(pattern) + '$', 'i');
+  return new RegExp((process.platform === 'darwin' ? '^.*/' : '^') + escape(pattern) + '$', 'i');
 
   function escape(x) {
     return x.replace(/(\W)/g, function(_, match) {


### PR DESCRIPTION
Processes names in osx, as listed by xps, are full paths, which are not matched by the regex created in `toRegExp` - `new RegExp('^' + escape(pattern) + '$', 'i')`, thus preventing `fuck-you` from finding processes.


Tested by modifying the `match` function:
```
function match(pid, pattern){ return function(process) {
  if (/firefox/.test(process.name)) console.log(process.name);
  return toRegExp(pattern).test(process.name)
  &&     process.pid !== pid;
}}
```
...running `fuck something` and getting this output:
```
/opt/homebrew-cask/Caskroom/firefox/latest/Firefox.app/Contents/MacOS/firefox
```

This is fixed by modifying the regex in `toRegExp` by replacing `^` with `^.*/` when on darwin (osx).
