### PR TITLE
[Fixes] Execute issue with windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,7 +119,7 @@ function match(pid, pattern){ return function(process) {
 
 // :: String -> RegExp
 function toRegExp(pattern) {
-  return new RegExp('^' + escape(pattern) + '$', 'i');
+  return new RegExp('^' + escape(pattern) + '(\.exe)?$', 'i');
 
   function escape(x) {
     return x.replace(/(\W)/g, function(_, match) {


### PR DESCRIPTION
Regular expression to ignore `*.exe` in windows to kill processes, Closes #20